### PR TITLE
chore: allow node 18 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "repository": "medipass/validate-provider-number",
   "engines": {
-    "node": "^16"
+    "node": ">=16"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "repository": "medipass/validate-provider-number",
   "engines": {
-    "node": "16"
+    "node": ">16"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "repository": "medipass/validate-provider-number",
   "engines": {
-    "node": ">16"
+    "node": "^16"
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This PR adds version `>=16` of a package to the package.json file. This is necessary in order to ensure that our repo's that will be running node 18 can install this package.