### PR TITLE
fix: invalid leading stem character

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -12,6 +12,10 @@ test("returns false for an invalid provider number (incorrect check digit)", () 
   expect(validateProviderNumber("2429582T")).toBeFalsy();
 });
 
+test("returns false for an invalid provider number (invalid leading stem character)", () => {
+  expect(validateProviderNumber("A200853K")).toBeFalsy();
+});
+
 test("returns false for an invalid provider number (no check digit)", () => {
   expect(validateProviderNumber("2429582")).toBeFalsy();
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@
 const locationCharacters = "0123456789ABCDEFGHJKLMNPQRTUVWXY";
 const checkCharacters = "YXWTLKJHFBA";
 const re = new RegExp(
-  `(\\d{5,6})([${locationCharacters}])([${checkCharacters}])`
+  `^(\\d{5,6})([${locationCharacters}])([${checkCharacters}])$`
 );
 
 function padLeftZero(content: string, len: number) {


### PR DESCRIPTION
The regular expression was not enforcing the string must start and end with the correct sequence of digits, location and check characters. In the case of the invalid provider number `A200853K`, the regular expression was falsly correct, as it matched 6 digits correctly (200853), however that regular expression should've failed because it should match against the **first 6** characters and ensure they're digits. 

Tightened up the regex to match clearwater and ensure the pattern is matched across the whole string exactly.

For reference, here's the invalid regular expression result previously when the validation was more loose for string `A200853K`:

```
[
    '200853K',
    '20085',
    '3',
    'K',
    index: 1,
    input: 'A200853K',
    groups: undefined
]
```