### PR TITLE
fix: versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "build:watch": "tsc -w",
     "check-types": "tsc --noEmit",
     "test": "jest",
-    "release": "pnpm run build && pnpm version from-git && pnpm publish"
+    "release:major": "pnpm run build && pnpm version major && pnpm publish",
+    "release:minor": "pnpm run build && pnpm version minor && pnpm publish",
+    "release:patch": "pnpm run build && pnpm version patch && pnpm publish",
+    "release:pre": "pnpm run build && pnpm version prerelease && pnpm publish"
   },
   "devDependencies": {
     "@types/jest": "29.2.4",


### PR DESCRIPTION
Misunderstood the `from-git` option to think it handled the versioning for us. But it just takes the already existing git tag. So we'll need to be explicit about the type of version change we want to make