### PR TITLE
feat: add validateMedibankProviderNumber

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,35 +14,55 @@ Or NPM:
 $ npm install validate-provider-number
 ```
 
-
-
 ## Usage
 
 ```js
 // Using commonjs
-const validateProviderNumber = require('validate-provider-number');
+const {
+  validateMedibankProviderNumber,
+  validateProviderNumber,
+} = require("validate-provider-number");
 
-validateProviderNumber('2429581T');
+validateProviderNumber("2429581T");
+// Returns true
+
+validateMedibankProviderNumber("A204983L");
 // Returns true
 
 // Using ES modules
-import { validateProviderNumber } from 'validate-provider-number';
+import {
+  validateMedibankProviderNumber,
+  validateProviderNumber,
+} from "validate-provider-number";
 
-validateProviderNumber('2429581T');
+validateProviderNumber("2429581T");
+// Returns true
+
+validateMedibankProviderNumber("A204983L");
 // Returns true
 ```
-
 
 ## API
 
 ### validateProviderNumber(input)
 
+Validates a Medicare provider number using the published checksum algorithm.
+
 #### input
 
 Type: `string`
 
-The provider number to validate
+The Medicare provider number to validate.
 
+### validateMedibankProviderNumber(input)
+
+Validates a Medibank provider number containing a profession prefix followed by a provider number that uses the Medicare checksum algorithm.
+
+#### input
+
+Type: `string`
+
+The Medibank provider number to validate.
 
 ## License
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,4 +1,4 @@
-import { validateProviderNumber } from ".";
+import { validateMedibankProviderNumber, validateProviderNumber } from ".";
 
 test("returns true for a valid provider number", () => {
   expect(validateProviderNumber("2429581T")).toBeTruthy();
@@ -23,3 +23,23 @@ test("returns false for an invalid provider number (no check digit)", () => {
 test("returns false for an invalid provider number (5 digit provider-stem)", () => {
   expect(validateProviderNumber("429581T")).toBeFalsy();
 });
+
+test.each(["A200853K", "A204983L", "a204983l"])(
+  "returns true for a valid Medibank provider number (%s)",
+  (providerNumber) => {
+    expect(validateMedibankProviderNumber(providerNumber)).toBeTruthy();
+  }
+);
+
+test.each([
+  ["incorrect check digit", "A204983B"],
+  ["missing profession prefix", "204983L"],
+  ["invalid profession prefix", "!204983L"],
+  ["more than one profession prefix", "AA204983L"],
+  ["invalid length", "A2429581T"],
+])(
+  "returns false for an invalid Medibank provider number (%s)",
+  (_, providerNumber) => {
+    expect(validateMedibankProviderNumber(providerNumber)).toBeFalsy();
+  }
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,9 @@ const checkCharacters = "YXWTLKJHFBA";
 const re = new RegExp(
   `^(\\d{5,6})([${locationCharacters}])([${checkCharacters}])$`
 );
+const medibankRe = new RegExp(
+  `^[A-Z](\\d{5}[${locationCharacters}][${checkCharacters}])$`
+);
 
 function padLeftZero(content: string, len: number) {
   if (content.length < len) {
@@ -60,7 +63,9 @@ export const validateProviderNumber = (providerNumber: string) => {
     return false;
   }
 
-  const [_, stemMatch, locationMatch, checkMatch] = matchGroups;
+  const stemMatch = matchGroups[1];
+  const locationMatch = matchGroups[2];
+  const checkMatch = matchGroups[3];
 
   const stem = padLeftZero(stemMatch, 6);
 
@@ -70,6 +75,23 @@ export const validateProviderNumber = (providerNumber: string) => {
   const remainder = (stemSum + plvSum) % 11;
 
   return checkMatch === checkCharacters.charAt(remainder);
+};
+
+/**
+ * Returns whether the provided string is a valid Medibank provider number.
+ *
+ * Medibank provider numbers prepend a profession character to a seven-character
+ * provider number that uses the Medicare checksum algorithm.
+ */
+export const validateMedibankProviderNumber = (providerNumber: string) => {
+  const matchGroups = providerNumber.toUpperCase().match(medibankRe);
+  if (!matchGroups) {
+    return false;
+  }
+
+  const providerNumberMatch = matchGroups[1];
+
+  return validateProviderNumber(providerNumberMatch);
 };
 
 export default validateProviderNumber;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small additive API with tests and docs; Medicare validation logic is reused rather than duplicated.
> 
> **Overview**
> Adds **`validateMedibankProviderNumber`**, which accepts an eight-character value with a single leading profession letter (`A–Z`) plus a seven-character Medicare-style number, then reuses the existing Medicare checksum via **`validateProviderNumber`**.
> 
> **`validateProviderNumber`** is refactored slightly (named capture destructuring instead of array destructuring with `_`); behavior for standard Medicare numbers is unchanged.
> 
> Documentation and tests cover Medibank valid/invalid cases (prefix, length, check digit, case normalization).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b97b684709f8e4d7f194c3d36f1ad0b0ac48c9fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->